### PR TITLE
Add token '`' to support kernel symbol read

### DIFF
--- a/include/ktap_types.h
+++ b/include/ktap_types.h
@@ -74,7 +74,7 @@ typedef union ktap_string {
 		unsigned int hash;
 		size_t len;  /* number of characters in string */
 	} tsv;
-        /* short string is stored here, just after tsv */
+	/* short string is stored here, just after tsv */
 } ktap_string;
 
 

--- a/test/symbol.kp
+++ b/test/symbol.kp
@@ -1,0 +1,14 @@
+#!/usr/bin/env ktap
+
+function failed() {
+	printf("failed\n");
+	exit(-1);
+}
+
+#-----------------------------------------#
+
+a = `generic_file_buffered_write`
+b = `generic_file_mmap`
+
+printf("generic_file_buffered_write: 0x%x\n", a);
+printf("generic_file_mmap: 0x%x\n", b);

--- a/userspace/ktapc.h
+++ b/userspace/ktapc.h
@@ -86,7 +86,7 @@ enum RESERVED {
 	TK_RETURN, TK_THEN, TK_TRUE, TK_UNTIL, TK_WHILE,
 	/* other terminal symbols */
 	TK_CONCAT, TK_DOTS, TK_EQ, TK_GE, TK_LE, TK_NE, TK_INCR, TK_DBCOLON,
-	TK_EOS, TK_NUMBER, TK_NAME, TK_STRING
+	TK_EOS, TK_NUMBER, TK_NAME, TK_STRING, TK_SYMBOL
 };
 
 /* number of reserved words */

--- a/userspace/lex.c
+++ b/userspace/lex.c
@@ -46,7 +46,7 @@ static const char *const ktap_tokens [] = {
 	"in", "local", "nil", "not", "or", "repeat",
 	"return", "then", "true", "until", "while",
 	"..", "...", "==", ">=", "<=", "!=", "+=", "::", "<eof>",
-	"<number>", "<name>", "<string>"
+	"<number>", "<name>", "<string>", "<symbol>"
 };
 
 #define save_and_next(ls) (save(ls, ls->current), next(ls))
@@ -519,6 +519,10 @@ static int llex(ktap_lexstate *ls, ktap_seminfo *seminfo)
 		case '"': case '\'': {  /* short literal strings */
 			read_string(ls, ls->current, seminfo);
 			return TK_STRING;
+		}
+		case '`': {  /* short literal symbols */
+			read_string(ls, ls->current, seminfo);
+			return TK_SYMBOL;
 		}
 		case '.': {  /* '.', '..', '...', or number */
 			save_and_next(ls);


### PR DESCRIPTION
When using "`symbol_name`" in the script, parser will read symbol name
from kernel. Then, the symbol is replaced by a constant number, which
indicates its address in the kernel, or makes the compile fail.

Tested:
test/symbol.kp: Parse symbol names.
