### PR TITLE
Fix the bug on parsing lines in KALLSYMS

### DIFF
--- a/userspace/util.c
+++ b/userspace/util.c
@@ -297,9 +297,9 @@ unsigned long ktapc_read_ksym(ktap_string *ts)
 			break;
 
 		line[--line_len] = '\0'; /* \n */
-		sym_addr = strtok(line, " ");
-		strtok(NULL, " ");
-		sym_name = strtok(NULL, " ");
+		sym_addr = strtok(line, " \t");
+		strtok(NULL, " \t");
+		sym_name = strtok(NULL, " \t");
 		if (strcmp(symbol, sym_name) == 0) {
 			ret = strtoul(sym_addr, NULL, 16);
 			break;


### PR DESCRIPTION
'\t' and ' ' can both be used to delimit words in lines of the file
/proc/kallsyms, so strtok should take both as the delimiter parameter.
