### PR TITLE
two fixes for run_test script

### DIFF
--- a/test/run_test.sh
+++ b/test/run_test.sh
@@ -47,6 +47,7 @@ ktaprun -o /dev/null ksym.kp
 
 echo "testing kill deadloop ktap script"
 $KTAP -e 'while (1) {}' &
+sleep 1
 pkill ktap
 sleep 1
 


### PR DESCRIPTION
- use POSIX syntax for shell function definition in run_test
  my sh in ubuntu does not support function keyword
- make sure deadloop test is killed by pkill
