### PR TITLE
print out ktap version on -V argument

### DIFF
--- a/userspace/main.c
+++ b/userspace/main.c
@@ -592,6 +592,12 @@ static void parse_option(int argc, char **argv)
 			}
 			break;
 		case 'V':
+#ifdef CONFIG_KTAP_FFI
+			usage("%s (with FFI)\n\n", KTAP_VERSION);
+#else
+			usage("%s\n\n", KTAP_VERSION);
+#endif
+			break;
 		case '?':
 		case 'h':
 			usage("");


### PR DESCRIPTION
With this, people can check whether the compiler is compiled with FFI support. Also we can run different set of FFI tests (with and without FFI compiled in) accordingly by checking the out here.
