### PR TITLE
Update parse_events.c

### DIFF
--- a/userspace/parse_events.c
+++ b/userspace/parse_events.c
@@ -75,6 +75,9 @@ static void idmap_set(int id)
 
 static void idmap_clear(int id)
 {
+	if (!idmap_is_set(id))
+		return;
+
 	id_nr--;
 	idmap[id / 8] = idmap[id / 8] & ~ (1 << (id % 8));
 }


### PR DESCRIPTION
in function idmap_clear():
If the id is not set yet, it shouldn't clear idmap and decrement id_nr.

for example:
idmap_set 10, 11, 12
idmap_clear 1
id_nr=2
id_array[0]=i ok
id_array[1]=i ok
id_array[2]=i illegal
