### PR TITLE
Add missing <stdarg.h> include

### DIFF
--- a/userspace/kp_util.h
+++ b/userspace/kp_util.h
@@ -1,6 +1,8 @@
 #ifndef __KTAP_UTIL_H__
 #define __KTAP_UTIL_H__
 
+#include <stdarg.h>
+
 #include "../include/ktap_bc.h"
 #include "../include/ktap_err.h"
 


### PR DESCRIPTION
Fixes:

In file included from userspace/kp_bcwrite.c:32:0:
userspace/kp_util.h:74:14: error: unknown type name ‘va_list’
   ErrMsg em, va_list argp);
              ^
userspace/kp_util.h:76:42: error: unknown type name ‘va_list’
 const char *kp_sprintfv(const char *fmt, va_list argp);
                                          ^
In file included from userspace/kp_lex.c:28:0:
userspace/kp_util.h:74:14: error: unknown type name ‘va_list’
   ErrMsg em, va_list argp);
              ^
userspace/kp_util.h:76:42: error: unknown type name ‘va_list’
 const char *kp_sprintfv(const char *fmt, va_list argp);

Signed-off-by: Thomas Petazzoni thomas.petazzoni@free-electrons.com
