### PR TITLE
Support compilation for 4.2 (ftrace_events cleanup)

### DIFF
--- a/runtime/kp_events.c
+++ b/runtime/kp_events.c
@@ -35,7 +35,7 @@
 const char *kp_event_tostr(ktap_state_t *ks)
 {
 	struct ktap_event_data *e = ks->current_event;
-	struct ftrace_event_call *call;
+	trace_event_call *call;
 	struct trace_iterator *iter;
 	struct trace_event *ev;
 	enum print_line_t ret = TRACE_TYPE_NO_CONSUME;
@@ -116,7 +116,7 @@ struct ftrace_event_field {
 	int                     is_signed;
 };
 
-static struct list_head *get_fields(struct ftrace_event_call *event_call)
+static struct list_head *get_fields(trace_event_call *event_call)
 {
 	if (!event_call->class->get_fields)
 		return &event_call->class->fields;
@@ -178,7 +178,7 @@ void kp_event_getarg(ktap_state_t *ks, ktap_val_t *ra, int idx)
 /* init all fields of event, for quick arg1..arg9 access */
 static int init_event_fields(ktap_state_t *ks, struct ktap_event *event)
 {
-	struct ftrace_event_call *event_call = event->perf->tp_event; 
+	trace_event_call *event_call = event->perf->tp_event;
 	struct ktap_event_field *event_fields = &event->fields[0];
 	struct ftrace_event_field *field;
 	struct list_head *head;
@@ -518,7 +518,7 @@ static void dry_run_callback(void *data, struct pt_regs *regs, long id)
 
 static void init_syscall_event_fields(struct ktap_event *event, int is_enter)
 {
-	struct ftrace_event_call *event_call;
+	trace_event_call *event_call;
 	struct ktap_event_field *event_fields = &event->fields[0];
 	struct syscall_metadata *meta = syscalls_metadata[event->syscall_nr];
 	int idx = 0;

--- a/runtime/kp_events.h
+++ b/runtime/kp_events.h
@@ -1,7 +1,7 @@
 #ifndef __KTAP_EVENTS_H__
 #define __KTAP_EVENTS_H__
 
-#include <linux/ftrace_event.h>
+#include "trace_events.h"
 #include <trace/syscall.h>
 #include <trace/events/syscalls.h>
 #include <linux/syscalls.h>

--- a/runtime/kp_transport.c
+++ b/runtime/kp_transport.c
@@ -19,8 +19,8 @@
  * 51 Franklin St - Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#include "trace_events.h"
 #include <linux/debugfs.h>
-#include <linux/ftrace_event.h>
 #include <linux/stacktrace.h>
 #include <linux/clocksource.h>
 #include <asm/uaccess.h>

--- a/runtime/kp_vm.c
+++ b/runtime/kp_vm.c
@@ -23,8 +23,8 @@
  * 51 Franklin St - Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#include "trace_events.h"
 #include <linux/slab.h>
-#include <linux/ftrace_event.h>
 #include <linux/signal.h>
 #include <linux/sched.h>
 #include <linux/uaccess.h>

--- a/runtime/lib_kdebug.c
+++ b/runtime/lib_kdebug.c
@@ -23,7 +23,7 @@
 #include <linux/ctype.h>
 #include <linux/slab.h>
 #include <linux/version.h>
-#include <linux/ftrace_event.h>
+#include "trace_events.h"
 #include "../include/ktap_types.h"
 #include "ktap.h"
 #include "kp_obj.h"

--- a/runtime/trace_events.h
+++ b/runtime/trace_events.h
@@ -1,0 +1,7 @@
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 2, 0)
+#include <linux/ftrace_event.h>
+typedef struct ftrace_event_call trace_event_call;
+#else
+#include <linux/trace_events.h>
+typedef struct trace_event_call trace_event_call;
+#endif


### PR DESCRIPTION
Upstream commit with cleanup/rename is e382608254e06c8109f40044f5e693f2e04f3899
("Merge tag 'trace-v4.2' of
git://git.kernel.org/pub/scm/linux/kernel/git/rostedt/linux-trace")

Debug-Bug-Id: #803241
Reported-by: wavexx@thregr.org