### PR TITLE
Fix build on kernels >=v4.2

### DIFF
--- a/runtime/kp_events.c
+++ b/runtime/kp_events.c
@@ -35,7 +35,7 @@
 const char *kp_event_tostr(ktap_state_t *ks)
 {
 	struct ktap_event_data *e = ks->current_event;
-	struct ftrace_event_call *call;
+	struct TRACE_EVENT_CALL_STRUCT *call;
 	struct trace_iterator *iter;
 	struct trace_event *ev;
 	enum print_line_t ret = TRACE_TYPE_NO_CONSUME;
@@ -116,7 +116,7 @@ struct ftrace_event_field {
 	int                     is_signed;
 };
 
-static struct list_head *get_fields(struct ftrace_event_call *event_call)
+static struct list_head *get_fields(struct TRACE_EVENT_CALL_STRUCT *event_call)
 {
 	if (!event_call->class->get_fields)
 		return &event_call->class->fields;
@@ -178,7 +178,7 @@ void kp_event_getarg(ktap_state_t *ks, ktap_val_t *ra, int idx)
 /* init all fields of event, for quick arg1..arg9 access */
 static int init_event_fields(ktap_state_t *ks, struct ktap_event *event)
 {
-	struct ftrace_event_call *event_call = event->perf->tp_event; 
+	struct TRACE_EVENT_CALL_STRUCT *event_call = event->perf->tp_event;
 	struct ktap_event_field *event_fields = &event->fields[0];
 	struct ftrace_event_field *field;
 	struct list_head *head;
@@ -518,7 +518,7 @@ static void dry_run_callback(void *data, struct pt_regs *regs, long id)
 
 static void init_syscall_event_fields(struct ktap_event *event, int is_enter)
 {
-	struct ftrace_event_call *event_call;
+	struct TRACE_EVENT_CALL_STRUCT *event_call;
 	struct ktap_event_field *event_fields = &event->fields[0];
 	struct syscall_metadata *meta = syscalls_metadata[event->syscall_nr];
 	int idx = 0;
@@ -589,7 +589,7 @@ static int syscall_event_register(ktap_state_t *ks, const char *event_name,
 		syscall_nr = get_syscall_num(event_name + 9);
 		callback = trace_syscall_exit;
 	}
-	
+
 	if (G(ks)->parm->dry_run)
 		callback = dry_run_callback;
 

--- a/runtime/kp_events.h
+++ b/runtime/kp_events.h
@@ -1,7 +1,13 @@
 #ifndef __KTAP_EVENTS_H__
 #define __KTAP_EVENTS_H__
 
+#include <linux/version.h>
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 2, 0)
 #include <linux/ftrace_event.h>
+#else
+#include <linux/trace_events.h>
+#endif
+
 #include <trace/syscall.h>
 #include <trace/events/syscalls.h>
 #include <linux/syscalls.h>

--- a/runtime/kp_transport.c
+++ b/runtime/kp_transport.c
@@ -19,8 +19,14 @@
  * 51 Franklin St - Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <linux/debugfs.h>
+#include <linux/version.h>
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 2, 0)
 #include <linux/ftrace_event.h>
+#else
+#include <linux/trace_events.h>
+#endif
+
+#include <linux/debugfs.h>
 #include <linux/stacktrace.h>
 #include <linux/clocksource.h>
 #include <asm/uaccess.h>
@@ -521,7 +527,7 @@ void kp_transport_event_write(ktap_state_t *ks, struct ktap_event_data *e)
 	int entry_size = e->data->raw->size;
 
 	event = ring_buffer_lock_reserve(buffer, entry_size +
-					 sizeof(struct ftrace_event_call *));
+					 sizeof(struct TRACE_EVENT_CALL_STRUCT *));
 	if (!event) {
 		KTAP_STATS(ks)->events_missed += 1;
 		return;

--- a/runtime/kp_vm.c
+++ b/runtime/kp_vm.c
@@ -23,8 +23,14 @@
  * 51 Franklin St - Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <linux/slab.h>
+#include <linux/version.h>
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 2, 0)
 #include <linux/ftrace_event.h>
+#else
+#include <linux/trace_events.h>
+#endif
+
+#include <linux/slab.h>
 #include <linux/signal.h>
 #include <linux/sched.h>
 #include <linux/uaccess.h>

--- a/runtime/ktap.h
+++ b/runtime/ktap.h
@@ -198,5 +198,11 @@ extern const char *kp_err_allmsg;
 #define TRACE_SEQ_PRINTF(s, ...) ({ trace_seq_printf(s, __VA_ARGS__); !trace_seq_has_overflowed(s); })
 #endif
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 2, 0)
+#define TRACE_EVENT_CALL_STRUCT ftrace_event_call
+#else
+#define TRACE_EVENT_CALL_STRUCT trace_event_call
+#endif
+
 #endif /* __KTAP_H__ */
 

--- a/runtime/lib_kdebug.c
+++ b/runtime/lib_kdebug.c
@@ -19,11 +19,17 @@
  * 51 Franklin St - Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#include <linux/version.h>
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 2, 0)
+#include <linux/ftrace_event.h>
+#else
+#include <linux/trace_events.h>
+#endif
+
 #include <linux/module.h>
 #include <linux/ctype.h>
 #include <linux/slab.h>
 #include <linux/version.h>
-#include <linux/ftrace_event.h>
 #include "../include/ktap_types.h"
 #include "ktap.h"
 #include "kp_obj.h"


### PR DESCRIPTION
This allows ktap to be built on newer kernels, which broke after the following
change renaming include/linux/ftrace_events.h:

af658dca221207174fc0a7bcdcd4cff7c589fdd8

Also, allow for the renaming of ftrace_event_call in the kernel in change:

2425bcb9240f8c97d793cb31c8e8d8d0a843fa29

Both of these were merged at commit e382608254e06c8109f40044f5e693f2e04f3899
in the upstream kernel source.