### PR TITLE
Fix: __GFP_WAIT has been replaced by __GFP_RECLAIM

### DIFF
--- a/runtime/kp_obj.c
+++ b/runtime/kp_obj.c
@@ -43,8 +43,13 @@ const char *kp_err_allmsg =
 ;
 
 /* memory allocation flag */
+#ifndef __GFP_WAIT
+#define KTAP_ALLOC_FLAGS ((GFP_KERNEL | __GFP_NORETRY | __GFP_NOWARN) \
+			 & ~__GFP_RECLAIM)
+#else
 #define KTAP_ALLOC_FLAGS ((GFP_KERNEL | __GFP_NORETRY | __GFP_NOWARN) \
 			 & ~__GFP_WAIT)
+#endif
 
 /*
  * TODO: It's not safe to call into facilities in the kernel at-large,


### PR DESCRIPTION
The change has been made in the following kernel commit
71baba4b92dc1fa1bc461742c6ab1942ec6034e9.

Signed-off-by: Mohamad Gebai <mohamad.gebai@gmail.com>