### PR TITLE
runtime: fix building on 4.3

### DIFF
--- a/runtime/kp_obj.c
+++ b/runtime/kp_obj.c
@@ -44,7 +44,7 @@ const char *kp_err_allmsg =
 
 /* memory allocation flag */
 #define KTAP_ALLOC_FLAGS ((GFP_KERNEL | __GFP_NORETRY | __GFP_NOWARN) \
-			 & ~__GFP_WAIT)
+			 & ~__GFP_RECLAIM)
 
 /*
  * TODO: It's not safe to call into facilities in the kernel at-large,

--- a/runtime/ktap.h
+++ b/runtime/ktap.h
@@ -198,5 +198,9 @@ extern const char *kp_err_allmsg;
 #define TRACE_SEQ_PRINTF(s, ...) ({ trace_seq_printf(s, __VA_ARGS__); !trace_seq_has_overflowed(s); })
 #endif
 
+#ifndef __GFP_RECLAIM
+#define __GFP_RECLAIM __GFP_WAIT
+#endif
+
 #endif /* __KTAP_H__ */
 


### PR DESCRIPTION
Upstream-kernel: 71baba4b92dc1fa1bc461742c6ab1942ec6034e9 ("mm, page_alloc:
rename __GFP_WAIT to __GFP_RECLAIM")
Introduced-in: b5e3725171468badcfe305571ab3c7777c8b0a68 ("some improvment")