### PR TITLE
runtime: update GFP_WAIT to GFP_RECLAIM

### DIFF
--- a/runtime/kp_obj.c
+++ b/runtime/kp_obj.c
@@ -42,9 +42,13 @@ const char *kp_err_allmsg =
 #include "../include/ktap_errmsg.h"
 ;
 
+#ifndef __GFP_RECLAIM
+#define __GFP_RECLAIM __GFP_WAIT
+#endif
+
 /* memory allocation flag */
 #define KTAP_ALLOC_FLAGS ((GFP_KERNEL | __GFP_NORETRY | __GFP_NOWARN) \
-			 & ~__GFP_WAIT)
+			 & ~__GFP_RECLAIM)
 
 /*
  * TODO: It's not safe to call into facilities in the kernel at-large,


### PR DESCRIPTION
Recently, the __GFP_WAIT macro was renamed to __GFP_RECLAIM in the
upstream kernel. Fix this (and add a backwards compatible macro
definition) so that ktap can be built for 4.6.2.

Signed-off-by: Aleksa Sarai <asarai@suse.de>