### PR TITLE
uprobe: Blacklist uretprobes on symbol _start

### DIFF
--- a/userspace/kp_parse_events.c
+++ b/userspace/kp_parse_events.c
@@ -500,6 +500,13 @@ static int uprobe_symbol_actor(const char *name, vaddr_t addr, void *arg)
 			"resolved to 0x%lx\n",
 			base->binary, name, (unsigned long)addr);
 
+        if (!strcmp(name, "_start") && base->ret_probe) {
+		verbose_printf("uprobe: symbol: \"%s\" "
+				"ret_probe blacklisted\n",
+				name);
+		return 0;
+        }
+
 	ret = write_uprobe_event(base->fd, base->ret_probe, base->binary,
 				 name, addr, base->fetch_args);
 	if (ret)

--- a/userspace/kp_parse_events.c
+++ b/userspace/kp_parse_events.c
@@ -498,7 +498,7 @@ static int uprobe_symbol_actor(const char *name, vaddr_t addr, void *arg)
 
 	verbose_printf("uprobe: binary: \"%s\" symbol \"%s\" "
 			"resolved to 0x%lx\n",
-			base->binary, base->symbol, (unsigned long)addr);
+			base->binary, name, (unsigned long)addr);
 
 	ret = write_uprobe_event(base->fd, base->ret_probe, base->binary,
 				 name, addr, base->fetch_args);


### PR DESCRIPTION
This fixes #102. Also fixes a cosmetic problem where running ktap with verbose flag would output lines like:

```
[verbose] parse_eventdef: sys[probe], event[/usr/bin/spd-say:*], filter[(null)]
[verbose] uprobe: binary: "/usr/bin/spd-say" symbol "*" resolved to 0x1e90
```

instead of the more informative:
```
[verbose] parse_eventdef: sys[probe], event[/usr/bin/spd-say:*], filter[(null)]
[verbose] uprobe: binary: "/usr/bin/spd-say" symbol "deregister_tm_clones" resolved to 0x1e90
```