### PR TITLE
Fix building for v4.8 kernel

### DIFF
--- a/runtime/kp_events.c
+++ b/runtime/kp_events.c
@@ -64,7 +64,7 @@ const char *kp_event_tostr(ktap_state_t *ks)
 	iter = kp_this_cpu_temp_buffer(ks);
 
 	trace_seq_init(&iter->seq);
-	iter->ent = e->data->raw->data;
+	iter->ent = TRACE_EVENT_RAW_DATA(e);
 
 	ev = &(call->event);
 	if (ev)
@@ -129,21 +129,21 @@ void kp_event_getarg(ktap_state_t *ks, ktap_val_t *ra, int idx)
 
 	switch (event_fields->type)  {
 	case KTAP_EVENT_FIELD_TYPE_INT: {
-		struct trace_entry *entry = e->data->raw->data;
+		struct trace_entry *entry = TRACE_EVENT_RAW_DATA(e);
 		void *value = (unsigned char *)entry + event_fields->offset;
 		int n = *(int *)value;
 		set_number(ra, n);
 		return;
 		}
 	case KTAP_EVENT_FIELD_TYPE_LONG: {
-		struct trace_entry *entry = e->data->raw->data;
+		struct trace_entry *entry = TRACE_EVENT_RAW_DATA(e);
 		void *value = (unsigned char *)entry + event_fields->offset;
 		long n = *(long *)value;
 		set_number(ra, n);
 		return;
 		}
 	case KTAP_EVENT_FIELD_TYPE_STRING: {
-		struct trace_entry *entry = e->data->raw->data;
+		struct trace_entry *entry = TRACE_EVENT_RAW_DATA(e);
 		ktap_str_t *ts;
 		void *value = (unsigned char *)entry + event_fields->offset;
 		ts = kp_str_newz(ks, (char *)value);

--- a/runtime/kp_transport.c
+++ b/runtime/kp_transport.c
@@ -514,7 +514,7 @@ void kp_transport_event_write(ktap_state_t *ks, struct ktap_event_data *e)
 {
 	struct ring_buffer *buffer = G(ks)->buffer;
 	struct ring_buffer_event *event;
-	struct trace_entry *ev_entry = e->data->raw->data;
+	struct trace_entry *ev_entry = TRACE_EVENT_RAW_DATA(e);
 	struct trace_entry *entry;
 	int entry_size = e->data->raw->size;
 

--- a/runtime/ktap.h
+++ b/runtime/ktap.h
@@ -202,5 +202,11 @@ extern const char *kp_err_allmsg;
 #define __GFP_RECLAIM __GFP_WAIT
 #endif
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 8, 0)
+#define TRACE_EVENT_RAW_DATA(e) ((e)->data->raw->frag.data)
+#else
+#define TRACE_EVENT_RAW_DATA(e) ((e)->data->raw->data)
+#endif
+
 #endif /* __KTAP_H__ */
 


### PR DESCRIPTION
This commit to v4.8-rc1 https://github.com/torvalds/linux/commit/7e3f977edd0bd9ea6104156feba95bb5ae9bdd38 changed perf_raw_record structure.
Added a macro to handle it